### PR TITLE
Fix issue https://github.com/antwerpes/ap_docchecklogin/issues/16

### DIFF
--- a/ext_localconf.php
+++ b/ext_localconf.php
@@ -28,4 +28,4 @@ if (!defined('TYPO3_MODE')) {
     'className' => 'Antwerpes\\ApDocchecklogin\\DocCheckAuthenticationService'
 ));
 
-$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['initFEuser'][] = 'EXT:ap_docchecklogin/Classes/DocCheckAuthenticationService.php:&Antwerpes\ApDocchecklogin\DocCheckAuthenticationService->bypassLoginForCrawling';
+$GLOBALS['TYPO3_CONF_VARS']['SC_OPTIONS']['tslib/class.tslib_fe.php']['initFEuser'][] = 'Antwerpes\\ApDocchecklogin\\DocCheckAuthenticationService->bypassLoginForCrawling';


### PR DESCRIPTION
with TYPO3 v9.5 you get an InvalidArgumentException which indicates following:

`Core: Exception handler (WEB): Uncaught TYPO3 Exception: #1294585866: No class named EXT:ap_docchecklogin/Classes/DocCheckAuthenticationService.php:&Antwerpes\ApDocchecklogin\DocCheckAuthenticationService | InvalidArgumentException thrown in file [...]/typo3/sysext/core/Classes/Utility/GeneralUtility.php in line 3585. Requested URL: https://xxxxx.xxx/
`

the solution of @martingebhardt fix this problem